### PR TITLE
Change modifier from `private[this]` to `private[uuid]` in `RichUUID`

### DIFF
--- a/src/main/scala/io/jvm/uuid/RichUUID.scala
+++ b/src/main/scala/io/jvm/uuid/RichUUID.scala
@@ -1,6 +1,6 @@
 package io.jvm.uuid
 
-private[this] object RichUUID {
+private[uuid] object RichUUID {
   /** Upper-case hexadecimal translation lookup. */
   private final val UppercaseLookup: Array[Char] = "0123456789ABCDEF".toCharArray
   /** Lower-case hexadecimal translation lookup. */


### PR DESCRIPTION
The compiler complains about this with:

  last tree to typer: TypeTree(object StaticUUID)
       tree position: line 12 of <console>
            tree tpe: io.jvm.uuid.StaticUUID.type
              symbol: object StaticUUID in package uuid
   symbol definition: class StaticUUID extends StaticUUID (a ModuleClassSymbol)
      symbol package: io.jvm.uuid
       symbol owners: object StaticUUID
           call site: class A in package $line6

I am not sure how this worked before but I get the above error with 2.12 and I assume it's because the methods in the companion object are used the class but are accessible only in the singleton object with `private[this]`